### PR TITLE
Fix: #7 Allow additional properties at the root of the values object

### DIFF
--- a/values.schema.json
+++ b/values.schema.json
@@ -64,7 +64,7 @@
     }
   },
 
-  "type": "object", "additionalProperties": false,
+  "type": "object", "additionalProperties": true,
   "required": ["cmak", "reconcile"],
 
   "properties": {


### PR DESCRIPTION
If this helm chart is included as a subchart, helm adds a `.Values.global` object to the values being compared to the schema. Allowing additional properties in the `.Values.*` namespace in addition to the `cmak` and `reconcile` properties makes the chart much easier to work with for everyone, while not affecting the object trees used by this particular operator.