### PR TITLE
support specifying a secret name for ingress object TLS  

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -17,7 +17,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.ingress.host | quote }}
-      secretName: {{ .Values.ingress.host | replace "." "-" | quote }}
+      secretName: {{ .Values.ingress.tls.secret | default (.Values.ingress.host | replace "." "-") | quote }}
 {{- end }}
   rules:
     - host: {{ .Values.ingress.host | quote }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -70,6 +70,12 @@
         "limits": { "type": "object", "title": "resource limits", "default": {} },
         "requests": { "type": "object", "title": "resource requests", "default": {} }
       }
+    },
+    "tls": {
+      "type": ["null", "object"], "title": "use TLS secret", "default": null,
+      "properties": {
+        "secret": { "type": "string", "title": "Secret name to attach to the ingress object" }
+      }
     }
   },
 
@@ -131,7 +137,7 @@
       "properties": {
         "host": { "type": "string", "title": "ingress host" },
         "path": { "type": "string", "title": "ingress path" },
-        "tls": { "type": "boolean", "title": "use TLS secret", "default": false },
+        "tls": { "$ref": "#/definitions/tls" },
         "labels": { "type": "object", "title": "optional ingress labels", "default": {} },
         "annotations": { "type": "object", "title": "optional ingress annotations", "default": {} }
       }

--- a/values.yaml
+++ b/values.yaml
@@ -89,7 +89,8 @@ ingress: null
   #
   # # Enable TLS configuration for the hostname defined at ingress.host
   # # secret name will be "${ingress.host.replace(".", "-")}"
-  # tls: false
+  # tls: null
+  #   # secret: null
   #
   # # optional ingress annotations
   # annotations: {}


### PR DESCRIPTION
this PR adds support for specifying a secretname in values for the TLS secret to use in the ingress object