### PR TITLE
feat: Extend the chart for basicAuth

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -77,13 +77,27 @@ spec:
           {{- range .Values.ui.extraArgs }}
           - {{ . | quote }}
           {{- end }}
-          env:
-          {{- if .Values.ui.consumerProperties }}
-          - name: CONSUMER_PROPERTIES_FILE
-            value:  /conf/consumer.properties
+          {{ if .Values.ui.authentication.enabled }}
+          - "-DbasicAuthentication.enabled=true"
+          - "-DbasicAuthentication.username={{ .Values.ui.authentication.username }}"
+          - "-DbasicAuthentication.password=${AUTHENTICATION_PASSWORD}"
           {{- end }}
-          {{- with .Values.ui.extraEnv -}}
-            {{  toYaml . | nindent 10 }}
+          {{- if or .Values.ui.consumerProperties .Values.ui.authentication.enabled .Values.ui.extraEnv }}
+          env:
+            {{- if .Values.ui.consumerProperties }}
+            - name: CONSUMER_PROPERTIES_FILE
+              value:  /conf/consumer.properties
+            {{- end }}
+            {{- with .Values.ui.extraEnv -}}
+              {{  toYaml . | nindent 10 }}
+            {{- end }}
+            {{- if .Values.ui.authentication.enabled }}
+            - name: AUTHENTICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cmak.name" . }}-auth
+                  key: password
+            {{- end }}
           {{- end }}
           readinessProbe:
             httpGet:

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -12,3 +12,14 @@ data:
   keystore: {{ .keystore.value }}
   {{- end -}}
 {{- end -}}
+{{ if .Values.ui.authentication.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cmak.name" . }}-auth
+  labels:
+    {{- include "cmak.labels" . | nindent 4 }}
+type: Opaque
+data:
+  password: {{ required "Please set ui.authentication.password" .Values.ui.authentication.password | b64enc | quote }}
+{{- end -}}

--- a/values.schema.json
+++ b/values.schema.json
@@ -105,6 +105,20 @@
           }
         }
       }
+    },
+    "authentication": {
+      "type": "object", "title": "Basic Authentication settings", "default": {}, "required": ["enabled", "username", "password"],
+      "properties": {
+        "enabled": {
+          "type": "boolean", "description": "Enable/Disable basic authentication", "default": false
+        },
+        "username": {
+          "type": "string", "description": "The username to set for basic authentication", "default": "admin"
+        },
+        "password": {
+          "type": "string", "description": "The password to set for basic authentication", "default": ""
+        }
+      }
     }
   },
   "type": "object", "required": ["cmak", "reconcile", "ui", "zk"],
@@ -167,7 +181,8 @@
         "resources": { "$ref":  "#/definitions/resources" },
         "consumerProperties": { "type": "object", "title": "provide key value base pairs for consumer properties according to java docs", "default": {} },
         "consumerPropertiesSsl": { "$ref": "#/definitions/consumerSsl" },
-        "extraEnv": { "type": "array", "title": "optional environment variables", "items": {"type": "object"}, "default": [] }
+        "extraEnv": { "type": "array", "title": "optional environment variables", "items": {"type": "object"}, "default": [] },
+        "authentication": { "$ref": "#/definitions/authentication" }
       }
     },
     "zk": {

--- a/values.yaml
+++ b/values.yaml
@@ -114,6 +114,12 @@ ui:
     #     configMapKeyRef:
     #       name: special-config
     #       key: SPECIAL_LEVEL
+  # Authentication settings
+  authentication:
+    enabled: false
+    username: admin
+    password: ""
+
 
 # various settings for Zookeeper container
 zk:


### PR DESCRIPTION
Extends the chart such that it is possible to use `basicAuth` by having the password mapped from a secret to an env-var.

This ensures that those with `read-only` access to a cluster cannot see the password, as it is not exposed in plain text in the deployment manifest. 

fixes: https://github.com/eshepelyuk/cmak-operator/issues/53

Additionally, ensures that `env` is only ever set in the chart, if any env is actually used. Without the `if or` a bug can occur whereby `env:` is null and results in a broken render