### PR TITLE
chore(helm): set default image tag to 1.1.1 for ui

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -64,7 +64,7 @@ reconcile:
 ui:
   image:
     repository: "ghcr.io/eshepelyuk/dckr/cmak-3.0.0.6"
-    tag: "1.1.0"
+    tag: "1.1.1"
     pullPolicy: IfNotPresent
   port: 9000
   # additional command line arguments


### PR DESCRIPTION
If we go with the default installation and create the deployment with the older release, this PR will set the UI image version to `1.1.1` by default.

https://github.com/eshepelyuk/cmak-docker/pkgs/container/dckr%2Fcmak-3.0.0.6